### PR TITLE
#10312 Git Submodules update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,10 +12,10 @@
 	url = https://github.com/nextcloud/announcementcenter.git
 [submodule "themes/cdsp-theme"]
 	path = themes/cdsp-theme
-	url = https://github.com/aafc-lli/cdsp-theme
+	url = https://github.com/aafc-lli/cdsp-theme.git
 [submodule "apps/notifications"]
 	path = apps/notifications
 	url = https://github.com/nextcloud/notifications.git
 [submodule "apps/user_saml"]
 	path = apps/user_saml
-	url = https://github.com/aafc-lli/cdsp-saml
+	url = https://github.com/aafc-lli/cdsp-saml.git


### PR DESCRIPTION
Git Submodules command wasn't updating the theme and user_saml plugins if the .git suffix is missing.

In addition, this keeps the urls consistent