### PR TITLE
#5841 Update workflow branch trigger

### DIFF
--- a/.github/workflows/lli.yml
+++ b/.github/workflows/lli.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - prod
       - uat
-      - qa
+      - dev
 
 jobs:
   build:


### PR DESCRIPTION
The github repo has been updated so the environment are now 'dev', 'uat' and 'prod'.  There's no qa anymore so updating the workflow so the correct branches trigger the workflow.